### PR TITLE
Update maps.coffee

### DIFF
--- a/scripts/maps.coffee
+++ b/scripts/maps.coffee
@@ -14,7 +14,7 @@ module.exports = (robot) ->
                 "&size=400x400&maptype=" +
                 mapType +
                 "&sensor=false" +
-                "&format=png" # So campfire knows it's an image
+                "&format=.png" # So campfire knows it's an image
     url      = "http://maps.google.com/maps?q=" +
                escape(location) +
               "&hl=en&sll=37.0625,-95.677068&sspn=73.579623,100.371094&vpsrc=0&hnear=" +


### PR DESCRIPTION
Adds a dot to the extension to fool (some) clients into showing the image inline. Works in Textual, doesn't in Linkinus
