### PR TITLE
Update to docs to support docs type and version separately.

### DIFF
--- a/scripts/docs.coffee
+++ b/scripts/docs.coffee
@@ -13,20 +13,29 @@
 cheerio   = require 'cheerio'
 htmlStrip = require 'htmlstrip-native'
 
+TARGET_VERSION = '4.2'
 SEARCH_URL = 'https://www.google.com/search'
 USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.116 Safari/537.36'
 #Rommie=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1309.0 Safari/537.17
 
 module.exports = (robot) ->
-  getQueryUrl = (version, query) ->
-    if version.match(/^3(.*)/i)
-      "site:three.laravel.com/docs #{query}"
-    else if version == 'api'
-      "site:laravel.com/api/4.1 #{query}"
-    else if version == 'php'
+  getQueryUrl = (doctype, version, query) ->
+    version = 3 if version?.match /^3(.*)/i
+
+    if doctype == 'api'
+      if version == 3
+        "site:l3.shihan.me/api #{query}"
+      else if version?
+        "site:laravel.com/api/#{version} #{query}"
+      else
+        "site:laravel.com/api/#{TARGET_VERSION} #{query}"
+    else if doctype == 'php'
       "site:php.net/manual/en #{query}"
     else
-      "site:laravel.com/docs #{query}"
+      if version == 3
+        "site:three.laravel.com/docs #{query}"
+      else
+        "site:laravel.com/docs #{query}"
 
   fetchResult = (query, callback) ->
     robot.http(SEARCH_URL)
@@ -39,28 +48,19 @@ module.exports = (robot) ->
         url = result.find('.st .f a').attr('href') ? result.find('h3.r a').attr('href')
         callback url if callback
 
-  robot.hear /(([^:,\s!]+)[:,\s]+)?!docs\s?([0-9.]+|api|dev|php)?\s(.*)/i, (msg) ->
+  robot.hear /(([^:,\s!]+)[:,\s]+)?!docs\s?(api|php)?\s?([0-9.]+)?\s?(.*)/i, (msg) ->
     user = msg.match[2]
-    version = msg.match[3]
-    query = msg.match[4]
+    doctype = msg.match[3]
+    version  = msg.match[4]
+    query = msg.match[5]
 
-    # quick and dirty urlify version string
-    # (beware if we get into 2 digit minor vers)
-    if (version != 'dev' or version != 'api')
-      if !version?
-        version = ''
-      else if version.length > 1
-        version = version.replace(/[\.]/g, "-").substr(0, 3)
-      else if version == '4'
-        version = ''
-
-    fetchResult getQueryUrl(version, query), (url) ->
-      return msg.send "No results for \"#{query}\"" unless url
+    fetchResult getQueryUrl(doctype, version, query), (url) ->
+      return msg.send "No results for \"#{query.substr(0,30)}\"" unless url
 
       response = url
       response = "#{user}: #{response}" if user
 
-      if version == 'php' and /function/.test url
+      if doctype == 'php' and /function/.test url
         robot.http(url).get() (err, res, body) ->
           $ = cheerio.load body
           methodSigContent = htmlStrip.html_strip $('.methodsynopsis').html(), compact_whitespace : true


### PR DESCRIPTION
Added support for API versions (3, 4.*)
This was brought up in issue #24

Limiting the response for No result, to avoid a possibly large query response
