### PR TITLE
Docs - PHP google site search has changed.

### DIFF
--- a/scripts/docs.coffee
+++ b/scripts/docs.coffee
@@ -24,7 +24,7 @@ module.exports = (robot) ->
     else if version == 'api'
       "site:laravel.com/api/4.1 #{query}"
     else if version == 'php'
-      "site:www.php.net/manual/en #{query}"
+      "site:php.net/manual/en #{query}"
     else
       "site:laravel.com/docs #{query}"
 


### PR DESCRIPTION
`site:www.php.net/manual/en #{query}` seems to be returning no results on google.
adjusted to `site:php.net/manual/en #{query}` and seems to be correct results.
