### PR TITLE
DOCSCONTRIB - adjusted the docs regex for old format

### DIFF
--- a/scripts/docs.coffee
+++ b/scripts/docs.coffee
@@ -66,4 +66,4 @@ module.exports = (robot) ->
         msg.send response
 
   robot.respond /show (?:([^\s!]+) )?docs for (?:(api|php) )?(?:([0-9.]+) )?(.+)/i, docFetcher
-  robot.hear /(?:([^:,\s!]+)[:,\s]+)?!docs(?: (api|php))?(?: ([0-9.]+))?(?:\s?(.+))/i, docFetcher
+  robot.hear /(?:([^:,\s!]+)[:,\s]+)?!docs (?: (api|php))?(?: ([0-9.]+))?(?:\s?(.+))/i, docFetcher


### PR DESCRIPTION
Added a space to the regex for !docs so it wont catch !docscontrib.

This should not mess with how the command is used, I hope. It should still catch everything it needs to.
