### PR TITLE
Docs - Allow for 4.x

### DIFF
--- a/scripts/docs.coffee
+++ b/scripts/docs.coffee
@@ -35,7 +35,7 @@ module.exports = (robot) ->
     else
       if version == 3
         "site:laravel3.veliovgroup.com/docs #{query}"
-      else if version == 'master'
+      else if version?
         "site:laravel.com/docs/#{version} #{query}"
       else
         "site:laravel.com/docs #{query}"


### PR DESCRIPTION
Google had indexed docs version 4.0-4.2 and master(5).

This allows for all of version 4.x to be accessible.
