### PR TITLE
Fix shipit's broken images

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -1,1 +1,1 @@
-["file-brain.coffee", "shipit.coffee"]
+["file-brain.coffee"]

--- a/scripts/shipit.coffee
+++ b/scripts/shipit.coffee
@@ -1,0 +1,35 @@
+# Description:
+#   Rodent Motivation
+#
+#   Set the environment variable HUBOT_SHIP_EXTRA_SQUIRRELS (to anything)
+#   for additional motivation
+#
+# Dependencies:
+#   None
+#
+# Configuration:
+#   HUBOT_SHIP_EXTRA_SQUIRRELS
+#
+# Commands:
+#   ship it - Display a motivation squirrel
+#
+# Author:
+#   maddox
+squirrels = [
+  "http://28.media.tumblr.com/tumblr_lybw63nzPp1r5bvcto1_500.jpg",
+  "http://i.imgur.com/DPVM1.png",
+  "http://d2f8dzk2mhcqts.cloudfront.net/0772_PEW_Roundup/09_Squirrel.jpg",
+  "http://www.cybersalt.org/images/funnypictures/s/supersquirrel.jpg",
+  "http://www.zmescience.com/wp-content/uploads/2010/09/squirrel.jpg",
+  "http://1.bp.blogspot.com/_v0neUj-VDa4/TFBEbqFQcII/AAAAAAAAFBU/E8kPNmF1h1E/s640/squirrelbacca-thumb.jpg",
+]
+
+module.exports = (robot) ->
+  # Enable a looser regex if environment variable is set
+  if process.env.HUBOT_SHIP_EXTRA_SQUIRRELS
+    regex = /ship(ping|z|s|ped)?\s*it/i
+  else
+    regex = /ship\s*it/i
+
+  robot.hear regex, (msg) ->
+    msg.send msg.random squirrels


### PR DESCRIPTION
The stock shipit script from hubot-scripts has a boat load of links that
no longer exist (it is 3.5yrs old after all) so this brings the script
into our own collection and removes all the broken image links.